### PR TITLE
Add documentation information to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,8 +122,8 @@ documentation locally are available [here](docs/README.md).
 
 ## Testing
 
-To run unit and type testing on the package, first install the required
-dependencies:
+To run unit, type testing and doctests on the package, first install the 
+required dependencies:
 
 ```
 (_snld3d) > conda install -y mypy pytest pytest-mock
@@ -139,6 +139,12 @@ To run the type tests, type the following from the root directory:
 
 ```
 (_snld3d) > mypy --install-types src
+```
+
+To run doctests, type the following from the root directory:
+
+```
+(_snld3d) > pytest --doctest-modules src
 ```
 
 ## Uninstall

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 
 [![unit tests](https://github.com/Data-Only-Greater/SNL-Delft3D-CEC-Verify/actions/workflows/unit_tests.yml/badge.svg)](https://github.com/Data-Only-Greater/SNL-Delft3D-CEC-Verify/actions/workflows/unit_tests.yml)
 [![static type checks](https://github.com/Data-Only-Greater/SNL-Delft3D-CEC-Verify/actions/workflows/static_type_checks.yml/badge.svg)](https://github.com/Data-Only-Greater/SNL-Delft3D-CEC-Verify/actions/workflows/static_type_checks.yml)
+[![documentation](https://github.com/Data-Only-Greater/SNL-Delft3D-CEC-Verify/actions/workflows/docs.yml/badge.svg)](https://github.com/Data-Only-Greater/SNL-Delft3D-CEC-Verify/actions/workflows/docs.yml)
 
 [![codecov](https://codecov.io/gh/Data-Only-Greater/SNL-Delft3D-CEC-Verify/branch/main/graph/badge.svg?token=JJCDDVNPS6)](https://codecov.io/gh/Data-Only-Greater/SNL-Delft3D-CEC-Verify)
 
@@ -113,9 +114,11 @@ called `validation_report`.
 
 ## Documentation
 
-Currently, the examples are the only indicative documentation of how
-`SNL-Delft3D-CEC-Verify` is used. Improved documentation of the available 
-features will be forthcoming in the near future.
+API documentation, which describes the classes and functions used in the 
+examples, can be found [here][9].
+
+Documentation updates will be ongoing. Instructions for building the 
+documentation locally are available [here](docs/README.md).
 
 ## Testing
 
@@ -179,3 +182,4 @@ Renewable Energy, 66, 729–746.
 [6]: https://github.com/openearth/delft3dfmpy
 [7]: https://github.com/django/django
 [8]: https://git-lfs.github.com/
+[9]: https://data-only-greater.github.io/SNL-Delft3D-CEC-Verify/api/snl_d3d_cec_verify.html


### PR DESCRIPTION
This commit adds the follow to the README.md file:

* Documentation build status badge
* Link to API documentation
* Doctest instructions