### PR TITLE
Add new variables for production runs

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -40,3 +40,5 @@ where = src
 [coverage:run]
 source = 
     src/snl_d3d_cec_verify
+omit =
+    src/snl_d3d_cec_verify/templates/*

--- a/src/snl_d3d_cec_verify/cases.py
+++ b/src/snl_d3d_cec_verify/cases.py
@@ -48,13 +48,13 @@ class CaseStudy:
     :param discharge: inlet boundary discharge, in cubic meters per second.
         Defaults to {discharge}
     :param horizontal_eddy_viscosity: uniform horizontal eddy viscosity, in
-        metres squared per second. Default to {horizontal_eddy_viscosity}
+        metres squared per second. Defaults to {horizontal_eddy_viscosity}
     :param horizontal_eddy_diffusivity: uniform horizontal eddy diffusivity,
-        in metres squared per second. Default to {horizontal_eddy_diffusivity}
+        in metres squared per second. Defaults to {horizontal_eddy_diffusivity}
     :param vertical_eddy_viscosity: uniform vertical eddy viscosity, in
-        metres squared per second. Default to {horizontal_eddy_viscosity}
+        metres squared per second. Defaults to {horizontal_eddy_viscosity}
     :param vertical_eddy_diffusivity: uniform vertical eddy diffusivity,
-        in metres squared per second. Default to {vertical_eddy_diffusivity}
+        in metres squared per second. Defaults to {vertical_eddy_diffusivity}
     :param simulate_turbines: simulate turbines, defaults to
         {simulate_turbines}
     :param horizontal_momentum_filter: use high-order horizontal momentum 

--- a/src/snl_d3d_cec_verify/cases.py
+++ b/src/snl_d3d_cec_verify/cases.py
@@ -47,8 +47,6 @@ class CaseStudy:
     :param turb_pos_z: turbine z-position, in meters. Defaults to {turb_pos_z}
     :param discharge: inlet boundary discharge, in cubic meters per second.
         Defaults to {discharge}
-    :param horizontal_momentum_filter: use high-order horizontal momentum 
-        filter. Defaults to {horizontal_momentum_filter}
     :param horizontal_eddy_viscosity: uniform horizontal eddy viscosity, in
         metres squared per second. Default to {horizontal_eddy_viscosity}
     :param horizontal_eddy_diffusivity: uniform horizontal eddy diffusivity,
@@ -57,6 +55,10 @@ class CaseStudy:
         metres squared per second. Default to {horizontal_eddy_viscosity}
     :param vertical_eddy_diffusivity: uniform vertical eddy diffusivity,
         in metres squared per second. Default to {vertical_eddy_diffusivity}
+    :param simulate_turbines: simulate turbines, defaults to
+        {simulate_turbines}
+    :param horizontal_momentum_filter: use high-order horizontal momentum 
+        filter. Defaults to {horizontal_momentum_filter}
     
     :raises ValueError: if variables with multiple values have different
         lengths
@@ -86,6 +88,9 @@ class CaseStudy:
     
     #: uniform vertical eddy diffusivity, in metres squared per second
     vertical_eddy_diffusivity: OneOrManyNum = 1e-06
+    
+    #: simulate turbines
+    simulate_turbines: bool = True
     
     #: use high-order horizontal momentum filter
     horizontal_momentum_filter: bool = True

--- a/src/snl_d3d_cec_verify/cases.py
+++ b/src/snl_d3d_cec_verify/cases.py
@@ -49,6 +49,14 @@ class CaseStudy:
         Defaults to {discharge}
     :param horizontal_momentum_filter: use high-order horizontal momentum 
         filter. Defaults to {horizontal_momentum_filter}
+    :param horizontal_eddy_viscosity: uniform horizontal eddy viscosity, in
+        metres squared per second. Default to {horizontal_eddy_viscosity}
+    :param horizontal_eddy_diffusivity: uniform horizontal eddy diffusivity,
+        in metres squared per second. Default to {horizontal_eddy_diffusivity}
+    :param vertical_eddy_viscosity: uniform vertical eddy viscosity, in
+        metres squared per second. Default to {horizontal_eddy_viscosity}
+    :param vertical_eddy_diffusivity: uniform vertical eddy diffusivity,
+        in metres squared per second. Default to {vertical_eddy_diffusivity}
     
     :raises ValueError: if variables with multiple values have different
         lengths
@@ -66,6 +74,18 @@ class CaseStudy:
     
     #: inlet boundary discharge, in cubic meters per second
     discharge: OneOrManyNum = 6.0574
+    
+    #: uniform horizontal eddy viscosity, in metres squared per second
+    horizontal_eddy_viscosity: OneOrManyNum = 1e-06
+    
+    #: uniform horizontal eddy diffusivity, in metres squared per second
+    horizontal_eddy_diffusivity: OneOrManyNum = 1e-06
+    
+    #: uniform vertical eddy viscosity, in metres squared per second
+    vertical_eddy_viscosity: OneOrManyNum = 1e-06
+    
+    #: uniform vertical eddy diffusivity, in metres squared per second
+    vertical_eddy_diffusivity: OneOrManyNum = 1e-06
     
     #: use high-order horizontal momentum filter
     horizontal_momentum_filter: bool = True

--- a/src/snl_d3d_cec_verify/copier.py
+++ b/src/snl_d3d_cec_verify/copier.py
@@ -108,7 +108,7 @@ def _get_posix_relative_paths(root: StrOrPath) -> List[str]:
             posix_file = rel_file.replace(os.sep, posixpath.sep)
             all_paths.append(posix_file)
     
-    return all_paths
+    return sorted(all_paths)
 
 
 def _template_copy(env: Environment,

--- a/src/snl_d3d_cec_verify/template.py
+++ b/src/snl_d3d_cec_verify/template.py
@@ -70,7 +70,10 @@ class Template:
     
     #: variables to ignore in the given :class:`.CaseStudy` objects when
     #: filling templates
-    no_template: List[str] = field(default_factory=lambda: ["dx", "dy"])
+    no_template: List[str] = field(
+                                default_factory=lambda: ["dx",
+                                                         "dy",
+                                                         "simulate_turbines"])
     
     def __call__(self, case: CaseStudy,
                        project_path: StrOrPath,
@@ -107,6 +110,18 @@ class Template:
         # Convert booleans to ints
         data = {field: int(value) if type(value) is bool else value
                                         for field, value in data.items()}
+        
+        # Add Turbines section if requested
+        if case.simulate_turbines:
+            simulate_turbines = (
+                "\n"
+                "[Turbines]\n"
+                "TurbineFile                       = turbines.ini\n"
+                "CurvesFile                        = curves.trb")
+        else:
+            simulate_turbines = ""
+        
+        data["simulate_turbines"] = simulate_turbines
         
         template_path = Path(self.template_path)
         project_path = Path(project_path)

--- a/src/snl_d3d_cec_verify/templates/fm/input/FlowFM.mdu
+++ b/src/snl_d3d_cec_verify/templates/fm/input/FlowFM.mdu
@@ -83,10 +83,10 @@ UnifFrictType                     = 1               # Uniform friction type (0: 
 UnifFrictCoef1D                   = 0.023           # Uniform friction coefficient in 1D links (0: no friction)
 UnifFrictCoefLin                  = 0               # Uniform linear friction coefficient for ocean models (0: no friction)
 Umodlin                           = 0               # Linear friction umod, for ifrctyp=4,5,6
-Vicouv                            = 1               # Uniform horizontal eddy viscosity
-Dicouv                            = 1               # Uniform horizontal eddy diffusivity
-Vicoww                            = 5E-05           # Uniform vertical eddy viscosity
-Dicoww                            = 5E-05           # Uniform vertical eddy diffusivity
+Vicouv                            = {{ '{:<15.9G}'.format(horizontal_eddy_viscosity) }} # Uniform horizontal eddy viscosity
+Dicouv                            = {{ '{:<15.9G}'.format(horizontal_eddy_diffusivity) }} # Uniform horizontal eddy diffusivity
+Vicoww                            = {{ '{:<15.9G}'.format(vertical_eddy_viscosity) }} # Uniform vertical eddy viscosity
+Dicoww                            = {{ '{:<15.9G}'.format(vertical_eddy_diffusivity) }} # Uniform vertical eddy diffusivity
 Vicwminb                          = 0               # Minimum viscosity in prod and buoyancy term
 Smagorinsky                       = 0               # Smagorinsky factor in horizontal turbulence
 Elder                             = 0               # Elder factor in horizontal turbulence

--- a/src/snl_d3d_cec_verify/templates/fm/input/FlowFM.mdu
+++ b/src/snl_d3d_cec_verify/templates/fm/input/FlowFM.mdu
@@ -227,7 +227,4 @@ StatsInterval                     =                 # Interval (in s) between si
 Writebalancefile                  = 0               # Write balance file (1: yes, 0: no)
 TimingsInterval                   =                 # Timings statistics output interval [Dd HH:MM:SS.ZZZ]
 Richardsononoutput                = 1               # Write Richardson numbers (1: yes, 0: no)
-
-[Turbines]
-TurbineFile                       = turbines.ini
-CurvesFile                        = curves.trb
+{{ simulate_turbines }}

--- a/tests/test_cases.py
+++ b/tests/test_cases.py
@@ -26,6 +26,7 @@ def test_casestudy_fields():
                                 'horizontal_eddy_diffusivity',
                                 'vertical_eddy_viscosity',
                                 'vertical_eddy_diffusivity',
+                                'simulate_turbines',
                                 'horizontal_momentum_filter']
 
 
@@ -55,6 +56,7 @@ def test_casestudy_values(cases):
                             1e-06,
                             1e-06,
                             1e-06,
+                            True,
                             True]
 
 

--- a/tests/test_cases.py
+++ b/tests/test_cases.py
@@ -22,6 +22,10 @@ def test_casestudy_fields():
                                 'turb_pos_y',
                                 'turb_pos_z',
                                 'discharge',
+                                'horizontal_eddy_viscosity',
+                                'horizontal_eddy_diffusivity',
+                                'vertical_eddy_viscosity',
+                                'vertical_eddy_diffusivity',
                                 'horizontal_momentum_filter']
 
 
@@ -47,6 +51,10 @@ def test_casestudy_values(cases):
                             3,
                             -1,
                             6.0574,
+                            1e-06,
+                            1e-06,
+                            1e-06,
+                            1e-06,
                             True]
 
 

--- a/tests/test_copier.py
+++ b/tests/test_copier.py
@@ -67,6 +67,46 @@ def test_template_copy(tmp_path):
     assert text == expected_text + "\n"
 
 
+@pytest.mark.parametrize("value,         expected", [
+                         (1e-6,          "1E-06          "),
+                         (1,             "1              "),
+                         (1 + 1e-8,      "1.00000001     "),
+                         (1.00000001e-6, "1.00000001E-06 ")])
+def test_template_copy_numeric(tmp_path, value, expected):
+    
+    # Fake a src and destination
+    src_path = tmp_path / "src_path"
+    src_path.mkdir()
+    
+    sub_d = src_path / "sub"
+    sub_d.mkdir()
+    
+    p = sub_d / "numbers.txt"
+    p.write_text("{{ '{:<15.9G}'.format(x) }}")
+    
+    dst_path = tmp_path / "dst_path"
+    dst_path.mkdir()
+    
+    sub_d = dst_path / "sub"
+    sub_d.mkdir()
+    
+    # Create a jinja environment
+    env = Environment(loader=FileSystemLoader(str(src_path)),
+                      keep_trailing_newline=True)
+    
+    # Set the content value
+    data = {"x": value}
+    
+    # Run the test
+    _template_copy(env, dst_path, "sub/numbers.txt", data)
+    expected_p = dst_path / "sub" / "numbers.txt"
+    
+    assert expected_p.exists()
+    
+    text = expected_p.read_text()
+    assert text == expected
+
+
 def test_template_copy_unicode_decode_error(tmp_path):
     
     # Fake a src and destination

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -49,6 +49,32 @@ def test_template_call(mocker):
                                                    case.dy)
 
 
+@pytest.mark.parametrize("simulate_turbines", [True, False])
+def test_template_fm_simulate_turbines(mocker, simulate_turbines):
+    
+    mocker.patch("snl_d3d_cec_verify.template.write_gridfm_rectangle",
+                 autospec=True)
+    mocker.patch("snl_d3d_cec_verify.copier._basic_copy",
+                 autospec=True)
+    mock_write = mocker.patch('snl_d3d_cec_verify.copier.open',
+                              mocker.mock_open())
+    
+    case = CaseStudy(simulate_turbines=simulate_turbines)
+    project_path = "mock_template"
+    
+    template = Template()
+    template(case, project_path)
+    
+    open_args, _ = mock_write.call_args_list[2]
+    
+    assert open_args[0] == Path("mock_template\\input\\FlowFM.mdu")
+    
+    handle = mock_write()
+    write_args, _ = handle.write.call_args_list[2]
+    
+    assert ("[Turbines]\n" in write_args[0]) is simulate_turbines
+
+
 def test_template_call_too_many_cases():
     
     template = Template("mock_template")

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -65,12 +65,12 @@ def test_template_fm_simulate_turbines(mocker, simulate_turbines):
     template = Template()
     template(case, project_path)
     
-    open_args, _ = mock_write.call_args_list[2]
+    open_args, _ = mock_write.call_args_list[1]
     
     assert open_args[0] == Path("mock_template/input/FlowFM.mdu")
     
     handle = mock_write()
-    write_args, _ = handle.write.call_args_list[2]
+    write_args, _ = handle.write.call_args_list[1]
     
     assert ("[Turbines]\n" in write_args[0]) is simulate_turbines
 

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -67,7 +67,7 @@ def test_template_fm_simulate_turbines(mocker, simulate_turbines):
     
     open_args, _ = mock_write.call_args_list[2]
     
-    assert open_args[0] == Path("mock_template\\input\\FlowFM.mdu")
+    assert open_args[0] == Path("mock_template/input/FlowFM.mdu")
     
     handle = mock_write()
     write_args, _ = handle.write.call_args_list[2]


### PR DESCRIPTION
New variables are added to the FM template and CaseStudy class for production runs. These are:

* **horizontal_eddy_viscosity**: uniform horizontal eddy viscosity, in metres squared per second. Defaults to 1e-06
* **horizontal_eddy_diffusivity**: uniform horizontal eddy diffusivity, in metres squared per second. Defaults to 1e-06
* **vertical_eddy_viscosity**: uniform vertical eddy viscosity, in  metres squared per second. Defaults to 1e-06
* **vertical_eddy_diffusivity**: uniform vertical eddy diffusivity, in metres squared per second.  Defaults to 1e-06
* **simulate_turbines**: simulate turbines, defaults to True
