### PR TITLE
Add Quick Start Documentation to use Conda Package

### DIFF
--- a/.conda/environment.yml
+++ b/.conda/environment.yml
@@ -22,6 +22,7 @@ dependencies:
   # Testing
   - mypy
   - pytest
+  - pytest-cov
   - pytest-mock
   - tox-conda
   # Documentation

--- a/.conda/environment.yml
+++ b/.conda/environment.yml
@@ -3,20 +3,22 @@ channels:
   - conda-forge
   - nodefaults
 dependencies:
-  # Package
-  - python>=3.9.9,<3.10
+  # Packaging
   - pip
-  - brotlipy
-  - geopandas-base
-  - jinja2
-  - netCDF4
-  - numpy>=1.21
-  - pandas
-  - pyyaml
-  - scipy
-  - shapely
-  - tabulate
-  - xarray>=0.20.1
+  - python-semantic-release
+  # Package
+  - python >=3.9.9,<3.10
+  - brotlipy =0.7.*
+  - geopandas-base =0.10.*
+  - jinja2 =3.0.*
+  - netCDF4 =1.5.*
+  - numpy =1.22.*
+  - pandas =1.3.*
+  - pyyaml =6.*
+  - scipy =1.7.*
+  - shapely =1.7.*
+  - tabulate =0.8.*
+  - xarray =0.20.*
   # Testing
   - mypy
   - pytest

--- a/.conda/environment.yml
+++ b/.conda/environment.yml
@@ -18,7 +18,7 @@ dependencies:
   - scipy =1.7.*
   - shapely =1.7.*
   - tabulate =0.8.*
-  - xarray =0.20.*
+  - xarray =0.20.*,>=0.20.1
   # Testing
   - mypy
   - pytest

--- a/.conda/environment.yml
+++ b/.conda/environment.yml
@@ -3,6 +3,7 @@ channels:
   - conda-forge
   - nodefaults
 dependencies:
+  # Package
   - python>=3.9.9,<3.10
   - pip
   - brotlipy
@@ -16,3 +17,13 @@ dependencies:
   - shapely
   - tabulate
   - xarray>=0.20.1
+  # Testing
+  - mypy
+  - pytest
+  - pytest-mock
+  - tox-conda
+  # Documentation
+  - sphinx
+  - sphinx-autodoc-typehints
+  - pip:
+    - insipid-sphinx-theme

--- a/.conda/recipe/meta.yaml
+++ b/.conda/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.4.2" %}
+{% set version = "0.4.3" %}
 
 package:
   name: snl-delft3d-cec-verify
@@ -29,17 +29,17 @@ requirements:
     - setuptools
   run:
     - python >=3.9.9,<3.10
-    - brotlipy
-    - geopandas-base
-    - jinja2
-    - netCDF4
-    - numpy >=1.21
-    - pandas
-    - pyyaml
-    - scipy
-    - shapely
-    - tabulate
-    - xarray >=0.20.1
+    - brotlipy =0.7.*
+    - geopandas-base =0.10.*
+    - jinja2 =3.0.*
+    - netCDF4 =1.5.*
+    - numpy =1.22.*
+    - pandas =1.3.*
+    - pyyaml =6.*
+    - scipy =1.7.*
+    - shapely =1.7.*
+    - tabulate =0.8.*
+    - xarray =0.20.*
 
 test:
   imports:

--- a/.conda/recipe/meta.yaml
+++ b/.conda/recipe/meta.yaml
@@ -39,7 +39,7 @@ requirements:
     - scipy =1.7.*
     - shapely =1.7.*
     - tabulate =0.8.*
-    - xarray =0.20.*
+    - xarray =0.20.*,>=0.20.1
 
 test:
   imports:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,14 +21,12 @@ jobs:
           python-version: ${{ matrix.python-version }}
           auto-activate-base: false
       - run: |
-          conda config --env --add channels conda-forge
           conda info
       - name: Install package
         run: |
           pip install --no-deps -e .
       - name: Run tests
         run: |
-          conda install -y pytest
           pytest --doctest-modules src
   build:
     runs-on: ubuntu-latest
@@ -48,7 +46,6 @@ jobs:
           python-version: '3.9'
           auto-activate-base: false
       - run: |
-          conda config --env --add channels conda-forge
           conda info
       - name: Install package
         run: |
@@ -57,8 +54,6 @@ jobs:
         run: echo "BUILD_DIR=$(mktemp -d -t pages-XXXXXXXXXX)" >> $GITHUB_ENV
       - name: Build docs
         run: |
-          conda install sphinx sphinx-autodoc-typehints
-          pip install insipid-sphinx-theme
           sphinx-build -b html -W --keep-going ./docs ${{ env.BUILD_DIR }}
       - name: Deploy
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}

--- a/.github/workflows/static_type_checks.yml
+++ b/.github/workflows/static_type_checks.yml
@@ -26,14 +26,12 @@ jobs:
           python-version: ${{ matrix.python-version }}
           auto-activate-base: false
       - run: |
-          conda config --env --add channels conda-forge
           conda info
       - name: Install package
         run: |
           pip install --no-deps -e .
       - name: Run checks
         run: |
-          conda install -y mypy
           mypy --install-types --non-interactive src
   status:
     name: Static Type Checks

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -21,14 +21,12 @@ jobs:
           python-version: ${{ matrix.python-version }}
           auto-activate-base: false
       - run: |
-          conda config --env --add channels conda-forge
           conda info
       - name: Install package
         run: |
           pip install --no-deps -e .
       - name: Run tests
         run: |
-          conda install -y pytest pytest-cov pytest-mock
           pytest --cov --cov-config=setup.cfg --cov-report=xml tests
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v2

--- a/README.md
+++ b/README.md
@@ -242,16 +242,17 @@ SNL-Delft3D-CEC-Verify package in development mode:
 
 ### Testing
 
-To run the unit tests, type the following from the root directory:
+To run the unit tests and get a coverage report, type the following from the 
+root directory:
 
 ```
-(_snld3d) > pytest
+(_snld3d) > pytest --cov-report term-missing --cov="./src/snl_d3d_cec_verify/"
 ```
 
 To run the type tests, type the following from the root directory:
 
 ```
-(_snld3d) > mypy --install-types src
+(_snld3d) > mypy --install-types --non-interactive src
 ```
 
 To run doctests, type the following from the root directory:
@@ -285,13 +286,13 @@ the `docs` directory:
 Then to build, for Windows:
 
 ```
-(_snld3d) > .\make.bat HTML
+(_snld3d) > .\make.bat html
 ```
 
 Alternatively for Linux
 
 ```
-(_snld3d) > make HTML
+(_snld3d) > make html
 ```
 
 The documentation can then be opened at the path `docs/_build/html/index.html`.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![documentation](https://github.com/Data-Only-Greater/SNL-Delft3D-CEC-Verify/actions/workflows/docs.yml/badge.svg)](https://github.com/Data-Only-Greater/SNL-Delft3D-CEC-Verify/actions/workflows/docs.yml)
 
 [![codecov](https://codecov.io/gh/Data-Only-Greater/SNL-Delft3D-CEC-Verify/branch/main/graph/badge.svg?token=JJCDDVNPS6)](https://codecov.io/gh/Data-Only-Greater/SNL-Delft3D-CEC-Verify)
+[![Conda](https://img.shields.io/conda/v/dataonlygreater/snl-delft3d-cec-verify?label=conda)](https://anaconda.org/dataonlygreater/snl-delft3d-cec-verify)
 
 # SNL-Delft3D-CEC-Verify
 
@@ -15,29 +16,78 @@ the [Delft3D Flexible Mesh Suite][102]. This package is used to verify the
 performance of SNL-Delft3D-FM-CEC by comparing against the 2014 flume 
 experiment conducted by Mycek et al.[[1]](#1).
 
-## Installation
+## Quick Start
 
-:warning: This repository uses [Git LFS][106] to store large files, so if you
-want to clone the repository, make sure to use `git lfs clone` to download all
-of the files and set up LFS.
+### Python Distribution
 
-The preferred method of installation is to use [Anaconda Python][103]. Download
-this package, open an Anaconda prompt and then change directory into the
-package root. Now create a conda environment using the following command:
+Due to the many non-Python binary requirements of the package dependencies, 
+installation requires the use of [Anaconda Python][103] or a fully free-to-use 
+equivalent, such as [Miniforge][114].
 
-```
-(base) > cd .conda
-(base) > conda env create --file environment.yml
-```
+### Install
 
-Activate the `_snld3d` environment, setup the channels, and then install the 
-SNL-Delft3D-CEC-Verify package:
+From a conda prompt create a named environment, set up the required channels
+and then install the `snl-delft3d-cec-verify` conda package:
 
 ```
-(base) > conda activate _snld3d
-(_snld3d) > conda config --env --add channels conda-forge
-(_snld3d) > pip install --no-deps -e .
+(base) > conda create -y -n snld3d --override-channels -c conda-forge "python>=3.9.9,<3.10" pip
+(base) > conda activate snld3d
+(snld3d) > conda config --env --add channels conda-forge --add channels dataonlygreater
+(snld3d) > conda config --env --set channel_priority strict
+(snld3d) > conda install -y snl-delft3d-cec-verify
 ```
+
+After this, working with SNL-Delft3D-CEC-Verify requires that the `snld3d`
+environment be activated:
+
+```
+(base) > conda activate snld3d
+(snld3d) >
+```
+
+### Update
+
+To update to the latest version of the conda package, using the `snld3d` 
+environment, type:
+
+```
+(snld3d) > conda update -y snl-delft3d-cec-verify
+```
+
+### Minimal Working Example
+
+The following presents an example of running a case study, based on the Mycek
+experiment, and collecting results at the turbine centre. Note that the token
+`<D3D_BIN>`, should be replaced with the path to the `bin` directory of the
+compiled Delft3D source code.
+
+```python
+>>> import tempfile
+>>> from snl_d3d_cec_verify import MycekStudy, Result, Runner, Template
+>>> template = Template()
+>>> runner = Runner(<D3D_BIN>)
+>>> case = MycekStudy()
+>>> with tempfile.TemporaryDirectory() as tmpdirname:
+...     template(case, tmpdirname)
+...     runner(tmpdirname)
+...     result = Result(tmpdirname)
+...     print(result.faces.extract_turbine_centre(-1, case))
+Dimensions:  (dim_0: 1)
+Coordinates:
+    $z$      int32 -1
+    time     datetime64[ns] 2001-01-01T01:00:00
+    $x$      (dim_0) int32 6
+    $y$      (dim_0) int32 3
+Dimensions without coordinates: dim_0
+Data variables:
+    k        (dim_0) float64 0.9993
+    $u$      (dim_0) float64 0.7147
+    $v$      (dim_0) float64 4.467e-17
+    $w$      (dim_0) float64 -0.002604
+
+```
+
+More detailed examples are provided in the section below.
 
 ## Examples
 
@@ -47,7 +97,7 @@ Examples are provided in the `examples` folder. As plots are generated in the
 examples, the `matplotlib` library is also required. To install it, type:
 
 ```
-(_snld3d) > conda install -y matplotlib
+(snld3d) > conda install -y matplotlib
 ```
 
 
@@ -56,7 +106,7 @@ can be optionally converted to Word format if the `pypandoc` package is
 installed. To install it, type:
 
 ```
-(_snld3d) > conda install -y pypandoc pandoc=2.12
+(snld3d) > conda install -y pypandoc pandoc=2.12
 ```
 
 Currently, a compiled copy of SNL-Delft3D-FM-CEC must be available for the 
@@ -71,7 +121,7 @@ setting the `D3D_BIN` environment variable, instead of copying the example
 files. To set `D3D_BIN`, for example, using PowerShell:
 
 ```
-(_snld3d) > $env:D3D_BIN = "\path\to\SNL-Delft3D-FM-CEC\src\bin"
+(snld3d) > $env:D3D_BIN = "\path\to\SNL-Delft3D-FM-CEC\src\bin"
 ```
 
 ### Basic Example
@@ -87,7 +137,7 @@ To run the example, move to the directory containing `basic.py` and then
 call Python:
 
 ```
-(_snld3d) > python basic.py
+(snld3d) > python basic.py
 ```
 
 If successful, the report files (and images) will be placed in a sub-directory
@@ -107,7 +157,7 @@ To run the example, move to the directory containing `validation.py` and then
 call Python:
 
 ```
-(_snld3d) > python validation.py
+(snld3d) > python validation.py
 ```
 
 If successful, the report files (and images) will be placed in a sub-directory
@@ -136,14 +186,14 @@ This example also requires the [convergence][109] package to be installed, by
 issuing the following command in the conda environment:
 
 ```
-(_snld3d) > pip install convergence
+(snld3d) > pip install convergence
 ```
 
 To run the example, move to the directory containing `grid_convergence.py` and
 then call Python:
 
 ```
-(_snld3d) > python grid_convergence.py
+(snld3d) > python grid_convergence.py
 ```
 
 If successful, the report files (and images) will be placed in a sub-directory 
@@ -156,19 +206,41 @@ folder, so that new simulations are conducted.
 ## Documentation
 
 API documentation, which describes the classes and functions used in the 
-examples, can be found [here][107].
+examples, can be found [here][107]. Documentation updates are ongoing. 
 
-Documentation updates will be ongoing. Instructions for building the 
-documentation locally are available [here](docs/README.md).
+## Development
 
-## Testing
+### Installation
 
-To run unit, type testing and doctests on the package, first install the 
-required dependencies:
+:warning: This repository uses [Git LFS][106] to store large files, so make 
+sure to use `git lfs clone` when cloning the repository to download all of the 
+files and set up LFS. For example:
 
 ```
-(_snld3d) > conda install -y mypy pytest pytest-mock tox-conda
+> git lfs clone https://github.com/Data-Only-Greater/SNL-Delft3D-CEC-Verify.git
 ```
+
+Due to the many non-Python binary requirements of the package dependencies, 
+installation requires the use of [Anaconda Python][103] or a fully free-to-use 
+equivalent, such as [Miniforge][114]. Open a conda prompt and then change 
+directory into the package root. Use the following commands to install the 
+package, testing and documentation dependencies into the `_snld3d` environment.
+
+```
+(base) > conda env create --file .conda/environment.yml
+```
+
+Activate the `_snld3d` environment, setup the channels, and then install the 
+SNL-Delft3D-CEC-Verify package in development mode:
+
+```
+(base) > conda activate _snld3d
+(_snld3d) > conda config --env --add channels conda-forge
+(_snld3d) > conda config --env --set channel_priority strict
+(_snld3d) > pip install --no-deps -e .
+```
+
+### Testing
 
 To run the unit tests, type the following from the root directory:
 
@@ -197,7 +269,34 @@ To run all three test suites simultaneously, invoke tox from the root directory:
 Note that tox creates a dedicated environment for the tests, which can be time 
 consuming on first run (or if there are any dependency changes).
 
-## Uninstall
+### Documentation
+
+HTML documentation is built using the [Sphinx][111] documentation system, with 
+the [sphinx-autodoc-typehints][112] plugin and the [insipid][113] theme.
+
+To build the documentation locally, activate the conda environment and move to
+the `docs` directory:
+
+```
+(base) > conda activate _snld3d
+(_snld3d) > cd docs
+```
+
+Then to build, for Windows:
+
+```
+(_snld3d) > .\make.bat HTML
+```
+
+Alternatively for Linux
+
+```
+(_snld3d) > make HTML
+```
+
+The documentation can then be opened at the path `docs/_build/html/index.html`.
+
+### Uninstall
 
 To remove the conda environment containing SNL-Delft3D-CEC-Verify, open an
 Ananconda prompt and type:
@@ -244,3 +343,7 @@ Retrieved 24 January 2022, from https://www.grc.nasa.gov/www/wind/valid/tutorial
 [108]: https://www.intel.com/content/www/us/en/products/sku/80806/intel-core-i74790-processor-8m-cache-up-to-4-00-ghz/specifications.html
 [109]: https://github.com/Data-Only-Greater/convergence
 [110]: https://data-only-greater.github.io/SNL-Delft3D-CEC-Verify/validation/index.html
+[111]: https://www.sphinx-doc.org/en/master/
+[112]: https://github.com/tox-dev/sphinx-autodoc-typehints
+[113]: https://insipid-sphinx-theme.readthedocs.io/
+[114]: https://github.com/conda-forge/miniforge

--- a/README.md
+++ b/README.md
@@ -296,6 +296,15 @@ Alternatively for Linux
 
 The documentation can then be opened at the path `docs/_build/html/index.html`.
 
+### Versioning
+
+Use [python-semantic-release][115] to update version numbers in the package.
+For instance, to add a commit that bumps the patch version, call:
+
+```
+(_snld3d) > semantic-release version --patch
+```
+
 ### Uninstall
 
 To remove the conda environment containing SNL-Delft3D-CEC-Verify, open an
@@ -347,3 +356,4 @@ Retrieved 24 January 2022, from https://www.grc.nasa.gov/www/wind/valid/tutorial
 [112]: https://github.com/tox-dev/sphinx-autodoc-typehints
 [113]: https://insipid-sphinx-theme.readthedocs.io/
 [114]: https://github.com/conda-forge/miniforge
+[115]: https://python-semantic-release.readthedocs.io/en/latest/

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,39 +1,11 @@
-# Documentation Build Instructions
+# SNL-Delft3D-CEC-Verify Documentation
 
-HTML documentation is built using the [Sphinx][1] documentation system, with the 
-[sphinx-autodoc-typehints][2] plugin and the [insipid][3] theme.
+This HTML documentation is built using the [Sphinx][1] documentation system, 
+with the [sphinx-autodoc-typehints][2] plugin and the [insipid][3] theme.
 
-## Dependency Installation
-
-```
-(base) > conda activate _snld3d
-(_snld3d) > conda install sphinx sphinx-autodoc-typehints
-(_snld3d) > pip install insipid-sphinx-theme
-```
-
-## Local Build
-
-Activate the conda environment and move to the `docs` directory
-
-```
-(base) > conda activate _snld3d
-(_snld3d) > cd docs
-```
-
-Then for Windows,
-
-```
-(_snld3d) > .\make.bat HTML
-```
-
-Alternatively for Linux
-
-```
-(_snld3d) > make HTML
-```
-
-The documentation can then be opened at the path `docs/_build/html/index.html`.
+The documentation is deployed [here][4].
 
 [1]: https://www.sphinx-doc.org/en/master/
 [2]: https://github.com/tox-dev/sphinx-autodoc-typehints
 [3]: https://insipid-sphinx-theme.readthedocs.io/
+[4]: https://data-only-greater.github.io/SNL-Delft3D-CEC-Verify/

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -27,7 +27,7 @@ copyright = '2022, Mathew Topper'
 author = 'Mathew Topper'
 
 # The full version, including alpha/beta/rc tags
-release = '0.3.0'
+release = '0.4.3'
 
 
 # -- General configuration ---------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,3 +10,12 @@ filterwarnings = [
     "ignore::DeprecationWarning:pywintypes",
 ]
 doctest_optionflags = "NORMALIZE_WHITESPACE"
+
+[tool.semantic_release]
+branch = "main"
+version_pattern = [
+    "setup.cfg:version = (\\d+\\.\\d+\\.\\d+)",
+    ".conda/recipe/meta.yaml:{{% set version = \"(\\d+\\.\\d+\\.\\d+)\" %}}",
+    "docs/conf.py:release = '(\\d+\\.\\d+\\.\\d+)'"
+]
+tag_commit = false

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = SNL-Delft3D-CEC-Verify
-version = 0.4.2
+version = 0.4.3
 author = Mathew Topper
 author_email = mathew.topper@dataonlygreater.com
 description = Automated verification of SNL-Delft3D-CEC based on the 2014 Mycek experiment


### PR DESCRIPTION
This commit updates the README documentation to include a quick start guide for normal users that installs the conda package, rather than from source. The old installation documentation is now moved to a new "Development" section. Additional changes are:

1. Pinning dependency package numbers to minor versions in attempt to avoid dependency driven failures.
1. Using [python-semantic-release](https://python-semantic-release.readthedocs.io/en/latest/) for updating version numbers in the source code.
1. Including all development dependencies in `environment.yaml`
1. Add a badge for the conda package
1. Bump to version 0.4.3
