### PR TITLE
Ignore build artefacts when pushing to gh-pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -56,7 +56,7 @@ jobs:
         run: |
           sphinx-build -b html -W --keep-going ./docs ${{ env.BUILD_DIR }}
       - name: Deploy
-        #if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -56,7 +56,7 @@ jobs:
         run: |
           sphinx-build -b html -W --keep-going ./docs ${{ env.BUILD_DIR }}
       - name: Deploy
-        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+        #if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,0 +1,2 @@
+# Sphinx build artefacts
+.doctrees/

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,2 +1,3 @@
 # Sphinx build artefacts
+.buildinfo
 .doctrees/

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -79,4 +79,7 @@ html_theme = 'insipid'
 # documentation, such as robots.txt or .htaccess. Relative paths are taken as 
 # relative to the configuration directory. They are copied to the output 
 # directory. They will overwrite any existing file of the same name.
-html_extra_path = ["README.md"]
+html_extra_path = [
+    ".gitignore",
+    "README.md",
+]


### PR DESCRIPTION
This commit adds a `.gitignore` file to the `docs` folder to ignore artefacts of the Sphinx build process when committing to the `gh-pages` branch.