### PR TITLE
Add Python 3.10 support

### DIFF
--- a/.conda/environment.yml
+++ b/.conda/environment.yml
@@ -10,15 +10,15 @@ dependencies:
   - python >=3.9.9,<3.11
   - brotlipy =0.7.*
   - geopandas-base =0.10.*
-  - jinja2 =3.0.*
+  - jinja2 =3.1.*
   - netCDF4 =1.5.*
-  - numpy =1.22.*
-  - pandas =1.3.*
+  - numpy =1.22.*,>=1.21
+  - pandas =1.4.*
   - pyyaml =6.*
-  - scipy =1.7.*
-  - shapely =1.7.*
+  - scipy =1.8.*
+  - shapely =1.8.*
   - tabulate =0.8.*
-  - xarray =0.20.*,>=0.20.1
+  - xarray =2022.3.*,>=0.20.1
   # Testing
   - mypy
   - pytest

--- a/.conda/environment.yml
+++ b/.conda/environment.yml
@@ -7,7 +7,7 @@ dependencies:
   - pip
   - python-semantic-release
   # Package
-  - python >=3.9.9,<3.10
+  - python >=3.9.9,<3.11
   - brotlipy =0.7.*
   - geopandas-base =0.10.*
   - jinja2 =3.0.*

--- a/.conda/recipe/meta.yaml
+++ b/.conda/recipe/meta.yaml
@@ -28,18 +28,18 @@ requirements:
     - python
     - setuptools
   run:
-    - python >=3.9.9,<3.10
+    - python >=3.9.9,<3.11
     - brotlipy =0.7.*
     - geopandas-base =0.10.*
-    - jinja2 =3.0.*
+    - jinja2 =3.1.*
     - netCDF4 =1.5.*
-    - numpy =1.22.*
-    - pandas =1.3.*
+    - numpy =1.22.*,>=1.21
+    - pandas =1.4.*
     - pyyaml =6.*
-    - scipy =1.7.*
-    - shapely =1.7.*
+    - scipy =1.8.*
+    - shapely =1.8.*
     - tabulate =0.8.*
-    - xarray =0.20.*,>=0.20.1
+    - xarray =2022.3.*,>=0.20.1
 
 test:
   imports:

--- a/.conda/recipe/meta.yaml
+++ b/.conda/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.6.1" %}
+{% set version = "0.7.0" %}
 
 package:
   name: snl-delft3d-cec-verify

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,8 @@ jobs:
       - uses: actions/upload-artifact@v3
         with:
           name: conda-package
-          path: $CONDA/conda-bld/noarch/snl-delft3d-cec-verify-*.tar.bz2
+          path: ${{env.CONDA}}/conda-bld/noarch/snl-delft3d-cec-verify-*.tar.bz2
+          if-no-files-found: error
   test:
     name: Conda Package Test
     needs: build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,7 +74,7 @@ jobs:
           conda index $CONDA_CHANNEL
       - name: Install package
         run: |
-          conda install --override-channels -c file://'$CONDA_CHANNEL' -c conda-forge snl-delft3d-cec-verify
+          conda install --override-channels -c file://$CONDA_CHANNEL -c conda-forge snl-delft3d-cec-verify
       - name: Extract test files
         run: |
           conda install --override-channels -c conda-forge conda-package-handling

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,6 +43,11 @@ jobs:
       matrix:
         os: [windows-latest, ubuntu-latest]
         python-version: ['3.9', '3.10']
+        include:
+          - arch: win-64
+            os: windows-latest
+          - arch: linux-64
+            os: ubuntu-latest
     defaults:
       run:
         shell: bash -l {0}
@@ -52,18 +57,24 @@ jobs:
       - uses: actions/download-artifact@v3
         with:
           name: conda-package
-      - name: Get package name
+      - name: Get package and channel name
         run: |
           pattern="snl-delft3d-cec-verify-*.tar.bz2"
           files=( $pattern )
           echo "CONDA_PKG=${files[0]}" >> $GITHUB_ENV
+          echo "CONDA_CHANNEL=channel/${{ matrix.arch }}" >> $GITHUB_ENV
       - uses: conda-incubator/setup-miniconda@v2
         with:
           python-version: ${{ matrix.python-version }}
           conda-build-version: "*"
+      - name: Setup local channel
+        run: |
+          mkdir -p $CONDA_CHANNEL
+          cp $CONDA_PKG $CONDA_CHANNEL
+          conda index $CONDA_CHANNEL
       - name: Install package
         run: |
-          conda install --override-channels -c conda-forge $CONDA_PKG
+          conda install --override-channels -c file://$CONDA_CHANNEL -c conda-forge snl-delft3d-cec-verify
       - name: Extract test files
         run: |
           conda install --override-channels -c conda-forge conda-package-handling
@@ -90,7 +101,7 @@ jobs:
           conda install -y anaconda-client
           anaconda -t ${{ secrets.CONDA_TOKEN }} upload -u dataonlygreater snl-delft3d-cec-verify-*.tar.bz2
   zip_examples:
-    name: Upload Examples
+    name: Release Example Upload
     needs: test
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,7 +66,7 @@ jobs:
           pattern="snl-delft3d-cec-verify-*.tar.bz2"
           files=( $pattern )
           echo "CONDA_PKG=${files[0]}" >> $GITHUB_ENV
-          echo "CONDA_CHANNEL=${{ runner.temp }}/channel/${{ matrix.arch }}" >> $GITHUB_ENV
+          echo "CONDA_CHANNEL=channel/${{ matrix.arch }}" >> $GITHUB_ENV
       - name: Setup local channel
         run: |
           mkdir -p $CONDA_CHANNEL

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,7 @@ jobs:
         with:
           name: conda-package
       - name: Get package name
-      - run: |
+        run: |
           pattern="snl-delft3d-cec-verify-*.tar.bz2"
           files=( $pattern )
           echo "CONDA_PKG=${files[0]}" >> $GITHUB_ENV
@@ -68,8 +68,7 @@ jobs:
         run: |
           cph extract $CONDA_PKG --dest src
       - name: Test package
-        run: |
-          pytest
+        run: pytest
         working-directory: src/info/test
   upload:
     name: Conda Package Upload

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,6 +54,10 @@ jobs:
     env:
       conda-directory: ${{ github.workspace }}/.conda
     steps:
+      - uses: conda-incubator/setup-miniconda@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+          conda-build-version: "*"
       - uses: actions/download-artifact@v3
         with:
           name: conda-package
@@ -62,11 +66,7 @@ jobs:
           pattern="snl-delft3d-cec-verify-*.tar.bz2"
           files=( $pattern )
           echo "CONDA_PKG=${files[0]}" >> $GITHUB_ENV
-          echo "CONDA_CHANNEL=channel/${{ matrix.arch }}" >> $GITHUB_ENV
-      - uses: conda-incubator/setup-miniconda@v2
-        with:
-          python-version: ${{ matrix.python-version }}
-          conda-build-version: "*"
+          echo "CONDA_CHANNEL=${{ runner.temp }}/channel/${{ matrix.arch }}" >> $GITHUB_ENV
       - name: Setup local channel
         run: |
           mkdir -p $CONDA_CHANNEL

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,11 +43,6 @@ jobs:
       matrix:
         os: [windows-latest, ubuntu-latest]
         python-version: ['3.9', '3.10']
-        include:
-          - arch: win-64
-            os: windows-latest
-          - arch: linux-64
-            os: ubuntu-latest
     defaults:
       run:
         shell: bash -l {0}
@@ -66,15 +61,22 @@ jobs:
           pattern="snl-delft3d-cec-verify-*.tar.bz2"
           files=( $pattern )
           echo "CONDA_PKG=${files[0]}" >> $GITHUB_ENV
-          echo CONDA_CHANNEL='${{ runner.temp }}/channel/${{ matrix.arch }}' >> $GITHUB_ENV
+          echo CONDA_CHANNEL='${{ runner.temp }}/channel' >> $GITHUB_ENV
       - name: Setup local channel
         run: |
-          mkdir -p $CONDA_CHANNEL
-          cp $CONDA_PKG $CONDA_CHANNEL
+          mkdir -p $CONDA_CHANNEL/noarch
+          cp $CONDA_PKG $CONDA_CHANNEL/noarch
           conda index $CONDA_CHANNEL
       - name: Install package
         run: |
-          conda install --override-channels -c file://$CONDA_CHANNEL -c conda-forge snl-delft3d-cec-verify
+          if [ "$RUNNER_OS" == "Linux" ]; then
+            conda install --override-channels -c file://$CONDA_CHANNEL -c conda-forge snl-delft3d-cec-verify
+          elif [ "$RUNNER_OS" == "Windows" ]; then
+            conda install --override-channels -c $CONDA_CHANNEL -c conda-forge snl-delft3d-cec-verify
+          else
+               echo "$RUNNER_OS not supported"
+               exit 1
+          fi
       - name: Extract test files
         run: |
           conda install --override-channels -c conda-forge conda-package-handling

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build:
-    name: Conda Build
+    name: Conda Package Build
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -54,6 +54,7 @@ jobs:
           name: conda-package
       - uses: conda-incubator/setup-miniconda@v2
         with:
+          python-version: ${{ matrix.python-version }}
           conda-build-version: "*"
       - name: Test conda package
         run: |
@@ -70,12 +71,10 @@ jobs:
         with:
           name: conda-package
       - uses: conda-incubator/setup-miniconda@v2
-        with:
-          conda-build-version: "*"
       - name: Upload conda package
         run: |
           conda install -y anaconda-client
-          # anaconda -t ${{ secrets.CONDA_TOKEN }} upload -u dataonlygreater snl-delft3d-cec-verify-*.tar.bz2
+          anaconda -t ${{ secrets.CONDA_TOKEN }} upload -u dataonlygreater snl-delft3d-cec-verify-*.tar.bz2
   zip_examples:
     name: Upload Examples
     needs: test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
           echo "CONDA=$CONDA" >> $GITHUB_ENV
       - name: Build conda package
         run: |
-          conda build --no-anaconda-upload --no-test --override-channels -c conda-forge recipe
+          conda build --no-anaconda-upload --override-channels -c conda-forge recipe
         working-directory: ${{env.conda-directory}}
       - uses: actions/upload-artifact@v3
         with:
@@ -52,13 +52,24 @@ jobs:
       - uses: actions/download-artifact@v3
         with:
           name: conda-package
+      - name: Get package name
+      - run: |
+          pattern="snl-delft3d-cec-verify-*.tar.bz2"
+          files=( $pattern )
+          echo "CONDA_PKG=${files[0]}" >> $GITHUB_ENV
       - uses: conda-incubator/setup-miniconda@v2
         with:
           python-version: ${{ matrix.python-version }}
           conda-build-version: "*"
-      - name: Test conda package
+      - name: Install conda package
         run: |
-          conda build --override-channels -c conda-forge --test snl-delft3d-cec-verify-*.tar.bz2
+          conda install --override-channels -c conda-forge $CONDA_PKG pytest pytest-mock
+      - name: Extract test files
+        run: |
+          cph extract $CONDA_PKG --dest src
+      - name: Test package
+        run: pytest
+        working-directory: src/info/test
   upload:
     name: Conda Package Upload
     needs: test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,7 +68,8 @@ jobs:
         run: |
           cph extract $CONDA_PKG --dest src
       - name: Test package
-        run: pytest
+        run: |
+          pytest
         working-directory: src/info/test
   upload:
     name: Conda Package Upload

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,6 +66,7 @@ jobs:
           conda install --override-channels -c conda-forge $CONDA_PKG
       - name: Extract test files
         run: |
+          conda install --override-channels -c conda-forge conda-package-handling
           cph extract $CONDA_PKG --dest src
       - name: Test package
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,7 +66,7 @@ jobs:
           pattern="snl-delft3d-cec-verify-*.tar.bz2"
           files=( $pattern )
           echo "CONDA_PKG=${files[0]}" >> $GITHUB_ENV
-          echo "CONDA_CHANNEL='${{ runner.temp }}/channel/${{ matrix.arch }}'" >> $GITHUB_ENV
+          echo CONDA_CHANNEL='${{ runner.temp }}/channel/${{ matrix.arch }}' >> $GITHUB_ENV
       - name: Setup local channel
         run: |
           mkdir -p $CONDA_CHANNEL

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,27 +14,67 @@ jobs:
         shell: bash -l {0}
     env:
       conda-directory: ${{ github.workspace }}/.conda
-    if: github.repository == 'Data-Only-Greater/SNL-Delft3D-CEC-Verify'
+    if: github.repository == 'H0R5E/SNL-Delft3D-CEC-Verify'
     steps:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
           lfs: 'true'
-      - name: Set GIT_DESCRIBE_NUMBER
-        run: echo "GIT_DESCRIBE_NUMBER=$(git log $(git describe --tags --abbrev=0)..HEAD --oneline | wc -l)" >> $GITHUB_ENV
       - uses: conda-incubator/setup-miniconda@v2
         with:
           conda-build-version: "*"
       - name: Build conda package
         run: |
-          conda build --no-anaconda-upload --override-channels -c conda-forge recipe
+          conda build --no-anaconda-upload --no-test --override-channels -c conda-forge recipe
         working-directory: ${{env.conda-directory}}
+      - uses: actions/upload-artifact@v3
+        with:
+          name: conda-package
+          path: $CONDA/conda-bld/noarch/snl-delft3d-cec-verify-*.tar.bz2
+  test:
+    name: Conda Package Test
+    needs: build
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [windows-latest, ubuntu-latest]
+        python-version: ['3.9', '3.10']
+    defaults:
+      run:
+        shell: bash -l {0}
+    env:
+      conda-directory: ${{ github.workspace }}/.conda
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          name: conda-package
+      - uses: conda-incubator/setup-miniconda@v2
+        with:
+          conda-build-version: "*"
+      - name: Test conda package
+        run: |
+          conda build --override-channels -c conda-forge --test snl-delft3d-cec-verify-*.tar.bz2
+  upload:
+    name: Conda Package Upload
+    needs: test
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash -l {0}
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          name: conda-package
+      - uses: conda-incubator/setup-miniconda@v2
+        with:
+          conda-build-version: "*"
       - name: Upload conda package
         run: |
           conda install -y anaconda-client
-          anaconda -t ${{ secrets.CONDA_TOKEN }} upload -u dataonlygreater $CONDA/conda-bld/noarch/snl-delft3d-cec-verify-*.tar.bz2
+          # anaconda -t ${{ secrets.CONDA_TOKEN }} upload -u dataonlygreater snl-delft3d-cec-verify-*.tar.bz2
   zip_examples:
     name: Upload Examples
+    needs: test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/upload-artifact@v3
         with:
           name: conda-package
-          path: ${{env.CONDA}}/conda-bld/noarch/snl-delft3d-cec-verify-*.tar.bz2
+          path: ${{CONDA}}/conda-bld/noarch/snl-delft3d-cec-verify-*.tar.bz2
           if-no-files-found: error
   test:
     name: Conda Package Test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,7 +66,7 @@ jobs:
           pattern="snl-delft3d-cec-verify-*.tar.bz2"
           files=( $pattern )
           echo "CONDA_PKG=${files[0]}" >> $GITHUB_ENV
-          echo "CONDA_CHANNEL=channel/${{ matrix.arch }}" >> $GITHUB_ENV
+          echo "CONDA_CHANNEL='${{ runner.temp }}/channel/${{ matrix.arch }}'" >> $GITHUB_ENV
       - name: Setup local channel
         run: |
           mkdir -p $CONDA_CHANNEL
@@ -74,7 +74,7 @@ jobs:
           conda index $CONDA_CHANNEL
       - name: Install package
         run: |
-          conda install --override-channels -c file://$CONDA_CHANNEL -c conda-forge snl-delft3d-cec-verify
+          conda install --override-channels -c file://'$CONDA_CHANNEL' -c conda-forge snl-delft3d-cec-verify
       - name: Extract test files
         run: |
           conda install --override-channels -c conda-forge conda-package-handling

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,9 @@ jobs:
       - uses: conda-incubator/setup-miniconda@v2
         with:
           conda-build-version: "*"
+      - name: Store CONDA variable
+        run: |
+          echo "CONDA=$CONDA" >> $GITHUB_ENV
       - name: Build conda package
         run: |
           conda build --no-anaconda-upload --no-test --override-channels -c conda-forge recipe
@@ -30,7 +33,7 @@ jobs:
       - uses: actions/upload-artifact@v3
         with:
           name: conda-package
-          path: ${{CONDA}}/conda-bld/noarch/snl-delft3d-cec-verify-*.tar.bz2
+          path: ${{env.CONDA}}/conda-bld/noarch/snl-delft3d-cec-verify-*.tar.bz2
           if-no-files-found: error
   test:
     name: Conda Package Test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,14 +61,16 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           conda-build-version: "*"
-      - name: Install conda package
+      - name: Install package
         run: |
-          conda install --override-channels -c conda-forge $CONDA_PKG pytest pytest-mock
+          conda install --override-channels -c conda-forge $CONDA_PKG
       - name: Extract test files
         run: |
           cph extract $CONDA_PKG --dest src
       - name: Test package
-        run: pytest
+        run: |
+          conda install --override-channels -c conda-forge pytest pytest-mock
+          pytest
         working-directory: src/info/test
   upload:
     name: Conda Package Upload

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, ubuntu-latest]
-        python-version: ['3.9']
+        python-version: ['3.9', '3.10']
     defaults:
       run:
         shell: bash -l {0}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -48,7 +48,7 @@ jobs:
         with:
           activate-environment: _snld3d
           environment-file: .conda/environment.yml
-          python-version: '3.9'
+          python-version: '3.10'
           auto-activate-base: false
       - run: |
           conda info

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -1,10 +1,5 @@
-name: Build Release
-
-on:
-  workflow_dispatch:
-  release:
-    types: [published]
-
+name: Packaging Tests
+on: [push, pull_request]
 jobs:
   build:
     name: Conda Package Build
@@ -14,7 +9,6 @@ jobs:
         shell: bash -l {0}
     env:
       conda-directory: ${{ github.workspace }}/.conda
-    if: github.repository == 'H0R5E/SNL-Delft3D-CEC-Verify'
     steps:
       - uses: actions/checkout@v2
         with:
@@ -28,7 +22,7 @@ jobs:
           echo "CONDA=$CONDA" >> $GITHUB_ENV
       - name: Build conda package
         run: |
-          conda build --no-anaconda-upload --override-channels -c conda-forge recipe
+          conda build --no-anaconda-upload --no-test --override-channels -c conda-forge recipe
         working-directory: ${{env.conda-directory}}
       - uses: actions/upload-artifact@v3
         with:
@@ -86,40 +80,19 @@ jobs:
           conda install --override-channels -c conda-forge pytest pytest-mock
           pytest
         working-directory: src/info/test
-  upload:
-    name: Conda Package Upload
-    needs: test
+  status:
+    name: Packaging Tests
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        shell: bash -l {0}
-    steps:
-      - uses: actions/download-artifact@v3
-        with:
-          name: conda-package
-      - uses: conda-incubator/setup-miniconda@v2
-      - name: Upload conda package
-        run: |
-          conda install -y anaconda-client
-          anaconda -t ${{ secrets.CONDA_TOKEN }} upload -u dataonlygreater snl-delft3d-cec-verify-*.tar.bz2
-  zip_examples:
-    name: Release Example Upload
     needs: test
-    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-          lfs: 'true'
-      - name: Set GIT_DESCRIBE_TAG
-        run: echo "GIT_DESCRIBE_TAG=$(git describe --tags --abbrev=0)" >> $GITHUB_ENV
-      - uses: papeloto/action-zip@v1
-        with:
-          files: examples/
-          dest: examples.zip
-      - name: Upload binaries to release
-        uses: svenstaro/upload-release-action@v2
-        with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: examples.zip
-          tag: ${{ env.GIT_DESCRIBE_TAG }}
+      - run: |
+          curl --request POST \
+          --url https://api.github.com/repos/${{ github.repository }}/statuses/${{ github.sha }} \
+          --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
+          --header 'content-type: application/json' \
+          --data '{
+            "context": "Packaging Tests",
+            "state": "success",
+            "description": "Packaging tests passed",
+            "target_url": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          }'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
         shell: bash -l {0}
     env:
       conda-directory: ${{ github.workspace }}/.conda
-    if: github.repository == 'H0R5E/SNL-Delft3D-CEC-Verify'
+    if: github.repository == 'Data-Only-Greater/SNL-Delft3D-CEC-Verify'
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,54 @@
+name: Build Release
+
+on:
+  workflow_dispatch:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    name: Conda Package
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash -l {0}
+    env:
+      conda-directory: ${{ github.workspace }}/.conda
+    if: github.repository == 'H0R5E/SNL-Delft3D-CEC-Verify'
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          lfs: 'true'
+      - uses: conda-incubator/setup-miniconda@v2
+        with:
+          conda-build-version: "*"
+      - name: Build
+        run: |
+          conda build --no-anaconda-upload --override-channels -c conda-forge recipe
+        working-directory: ${{env.conda-directory}}
+      - name: Upload
+        run: |
+          conda install -y anaconda-client
+          anaconda -t ${{ secrets.CONDA_TOKEN }} upload -u dataonlygreater $CONDA/conda-bld/noarch/snl-delft3d-cec-verify-*.tar.bz2
+  zip_examples:
+    name: Examples
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          lfs: 'true'
+      - name: Set GIT_DESCRIBE_TAG
+        run: echo "GIT_DESCRIBE_TAG=$(git describe --tags --abbrev=0)" >> $GITHUB_ENV
+      - uses: papeloto/action-zip@v1
+        with:
+          files: examples/
+          dest: examples.zip
+      - name: Upload
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: examples.zip
+          tag: ${{ env.GIT_DESCRIBE_TAG }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,6 @@ jobs:
           anaconda -t ${{ secrets.CONDA_TOKEN }} upload -u dataonlygreater $CONDA/conda-bld/noarch/snl-delft3d-cec-verify-*.tar.bz2
   zip_examples:
     name: Examples
-    needs: test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/static_type_checks.yml
+++ b/.github/workflows/static_type_checks.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, ubuntu-latest]
-        python-version: ['3.9']
+        python-version: ['3.9', '3.10']
     defaults:
       run:
         shell: bash -l {0}

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, ubuntu-latest]
-        python-version: ['3.9']
+        python-version: ['3.9', '3.10']
     defaults:
       run:
         shell: bash -l {0}

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ From a conda prompt create a named environment in which to install the
 for future updates:
 
 ```
-(base) > conda create -y -n snld3d --override-channels -c conda-forge -c dataonlygreater snl-delft3d-cec-verify=0.6.1
+(base) > conda create -y -n snld3d --override-channels -c conda-forge -c dataonlygreater snl-delft3d-cec-verify=0.7.0
 (base) > conda activate snld3d
 (snld3d) > conda config --env --add channels conda-forge --add channels dataonlygreater
 (snld3d) > conda config --env --set channel_priority strict

--- a/docs/_assets/gh-pages-redirect.html
+++ b/docs/_assets/gh-pages-redirect.html
@@ -3,7 +3,7 @@
   <head>
     <title>Redirecting to latest version</title>
     <meta charset="utf-8">
-    <meta http-equiv="refresh" content="0; url=./v0.6.1/index.html">
-    <link rel="canonical" href="https://data-only-greater.github.io/SNL-Delft3D-CEC-Verify/v0.6.1/index.html">
+    <meta http-equiv="refresh" content="0; url=./v0.7.0/index.html">
+    <link rel="canonical" href="https://data-only-greater.github.io/SNL-Delft3D-CEC-Verify/v0.7.0/index.html">
   </head>
 </html>

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -25,7 +25,7 @@ copyright = '2022, Mathew Topper'
 author = 'Mathew Topper'
 
 # The full version, including alpha/beta/rc tags
-release = '0.6.1'
+release = '0.7.0'
 
 
 # -- General configuration ---------------------------------------------------
@@ -57,7 +57,7 @@ smv_branch_whitelist = r'(main)$'
 smv_remote_whitelist = r'^(origin)$'
 smv_tag_whitelist = r'^v(\d+\.\d+\.\d+)$' # r'^v(?!0.4.0|0.4.1|0.4.2)\d+\.\d+\.\d+$'
 smv_released_pattern = r'^refs/tags/.*$'
-smv_latest_version = 'v0.6.1'
+smv_latest_version = 'v0.7.0'
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,7 @@ zip_safe = False
 package_dir =
     = src
 packages = find:
-python_requires = >=3.9, <3.10
+python_requires = >=3.9, <3.11
 install_requires =
     geopandas
     jinja2

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = SNL-Delft3D-CEC-Verify
-version = 0.6.1
+version = 0.7.0
 author = Mathew Topper
 author_email = mathew.topper@dataonlygreater.com
 description = Automated verification of SNL-Delft3D-CEC based on the 2014 Mycek experiment

--- a/src/snl_d3d_cec_verify/result/edges.py
+++ b/src/snl_d3d_cec_verify/result/edges.py
@@ -2,16 +2,20 @@
 
 from __future__ import annotations
 
+import warnings
 import collections
 from typing import Dict, Optional
 from dataclasses import dataclass, field
 
 import numpy as np
 import pandas as pd # type: ignore
-import geopandas as gpd # type: ignore
 import xarray as xr
 from shapely.geometry import LineString # type: ignore
 from shapely.geometry.base import BaseGeometry # type: ignore
+
+with warnings.catch_warnings():
+    warnings.filterwarnings("ignore", category=DeprecationWarning)
+    import geopandas as gpd # type: ignore
 
 from .base import _TimeStepResolver
 from ..types import StrOrPath
@@ -123,9 +127,8 @@ class Edges(_TimeStepResolver):
         if self._frame is None:
             self._frame = frame
         else:
-            self._frame = self._frame.append(frame,
-                                             ignore_index=True,
-                                             sort=False)
+            self._frame = pd.concat([self._frame, frame],
+                                    ignore_index=True)
         
         self._t_steps[t_step] = pd.Timestamp(frame["time"].unique().take(0))
 
@@ -169,7 +172,7 @@ def _map_to_edges_geoframe(map_path: StrOrPath,
                 index = int(edge_face_values[iedge, iface]) - 1
                 
                 if index < 0:
-                    p = np.array(line.centroid)
+                    p = np.array(line.centroid.coords)
                 else:
                     x = face_x_values[index]
                     y = face_y_values[index]

--- a/src/snl_d3d_cec_verify/result/faces.py
+++ b/src/snl_d3d_cec_verify/result/faces.py
@@ -489,9 +489,8 @@ class Faces(ABC, _FacesDataClassMixin):
         if self._frame is None:
             self._frame = frame
         else:
-            self._frame = self._frame.append(frame,
-                                             ignore_index=True,
-                                             sort=False)
+            self._frame = pd.concat([self._frame, frame],
+                                    ignore_index=True)
         
         self._t_steps[t_step] = pd.Timestamp(frame["time"].unique().take(0))
     

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -1,5 +1,9 @@
 # -*- coding: utf-8 -*-
 
+import sys
+
+import pytest
+
 from snl_d3d_cec_verify._docs import docstringtemplate
 
 
@@ -39,6 +43,15 @@ def test_docstringtemplate_classmethod():
     assert "defaults to ``2``" in f.__func__.__doc__
 
 
-def test_docstringtemplate_staticmethod():
+@pytest.mark.skipif(sys.version_info >= (3, 10),
+                    reason="Requires Python == 3.9")
+def test_docstringtemplate_staticmethod_py39():
     f = docstringtemplate(Mock.__dict__['static_method'])
     assert "defaults to ``3``" in f.__func__.__doc__
+
+
+@pytest.mark.skipif(sys.version_info == (3, 9),
+                    reason="Requires Python >= 3.10")
+def test_docstringtemplate_staticmethod_py310():
+    f = docstringtemplate(Mock.__dict__['static_method'])
+    assert "defaults to ``3``" in f.__doc__

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -43,14 +43,20 @@ def test_docstringtemplate_classmethod():
     assert "defaults to ``2``" in f.__func__.__doc__
 
 
-@pytest.mark.skipif(sys.version_info >= (3, 10),
+def is_python_version(major, minor):
+    if major != sys.version_info.major: return False
+    if minor != sys.version_info.minor: return False
+    return True
+
+
+@pytest.mark.skipif(not is_python_version(3, 9),
                     reason="Requires Python == 3.9")
 def test_docstringtemplate_staticmethod_py39():
     f = docstringtemplate(Mock.__dict__['static_method'])
     assert "defaults to ``3``" in f.__func__.__doc__
 
 
-@pytest.mark.skipif(sys.version_info == (3, 9),
+@pytest.mark.skipif(is_python_version(3, 9),
                     reason="Requires Python >= 3.10")
 def test_docstringtemplate_staticmethod_py310():
     f = docstringtemplate(Mock.__dict__['static_method'])

--- a/tests/test_result_edges.py
+++ b/tests/test_result_edges.py
@@ -1,9 +1,14 @@
 # -*- coding: utf-8 -*-
 
+import warnings
+
 import pandas as pd
 import pytest
-import geopandas as gpd
 from shapely.geometry import LineString
+
+with warnings.catch_warnings():
+    warnings.filterwarnings("ignore", category=DeprecationWarning)
+    import geopandas as gpd
 
 from snl_d3d_cec_verify.result.edges import _map_to_edges_geoframe, Edges
 

--- a/tests/test_result_faces.py
+++ b/tests/test_result_faces.py
@@ -1,9 +1,14 @@
 # -*- coding: utf-8 -*-
 
+import warnings
+
 import numpy as np
 import pandas as pd
-import xarray as xr
 import pytest
+
+with warnings.catch_warnings():
+    warnings.filterwarnings("ignore", category=DeprecationWarning)
+    import xarray as xr
 
 from snl_d3d_cec_verify.cases import CaseStudy
 from snl_d3d_cec_verify.result.faces import (_check_case_study,

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 requires = tox-conda
 envlist =
-    {py39}
+    {py39, py310}
 
 [testenv]
 conda_deps=

--- a/tox.ini
+++ b/tox.ini
@@ -5,16 +5,17 @@ envlist =
 
 [testenv]
 conda_deps=
-    geopandas-base
-    jinja2
-    netCDF4
-    numpy>=1.21
-    pandas
-    pyyaml
-    scipy
-    shapely
-    tabulate
-    xarray>=0.20.1
+    brotlipy =0.7.*
+    geopandas-base =0.10.*
+    jinja2 =3.1.*
+    netCDF4 =1.5.*
+    numpy =1.22.*,>=1.21
+    pandas =1.4.*
+    pyyaml =6.*
+    scipy =1.8.*
+    shapely =1.8.*
+    tabulate =0.8.*
+    xarray =2022.3.*,>=0.20.1
     mypy
     pytest
     pytest-cov


### PR DESCRIPTION
This PR adds support for Python 3.10 and updates the dependencies to a working set for both versions 3.9 and 3.10. In addition, packaging tests are added which builds and tests the conda packaging system for each push / PR on the main branch.

Version bump to 0.7.0